### PR TITLE
updated README.md file to have working links to X and Added SECURITY.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,6 @@ Mondays are our “Tech Topic” consisting of a theme and a guest. <br>
 Wednesdays are our “I’m a Dev, AMA” where YOU bring questions for an experienced dev. <br>
 Fridays we celebrate our wins for the week! Join us and let us know some great things you accomplished through the week!
 
-To listen, follow the hosts for show links: <a href="x.com/tasonjorres">Jason Torres</a> & <a href="x.com/arcadejacob">Jacob Ashley</a>
+To listen, follow the hosts for show links:
+
+[Jason Torres](https://twitter.com/TasonJorres) **&** [Jacob Ashley](https://twitter.com/arcadejacob)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# TechCommute Security Policy
+
+## Reporting a Vulnerability
+
+### Reporting a Vulnerability
+
+We take the security of our software at TechCommute very seriously. If you have discovered a security vulnerability in our software, we urge you to inform us immediately. We are committed to investigating all legitimate reports and working diligently to fix any issues promptly.
+
+#### How to Report a Vulnerability
+
+1. **Do Not Publicly Disclose**: Public disclosure of a vulnerability can put the entire community at risk. If you discover a security issue, please keep it confidential and allow us to address it.
+
+2. **Contact**: Directly message either [Jason Torres](https://twitter.com/TasonJorres) or [Jacob Ashley](https://twitter.com/arcadejacob) in X. Please provide as much information as possible about the vulnerability, including as many of the following as possible, descriptions, proof-of-concept, steps to reproduce, and an impact analysis.
+
+3. **Timing**: After reporting a vulnerability, please allow us a reasonable amount of time to resolve the issue before disclosing it to others.
+
+4. **Anonymous Reporting**: If you wish to remain anonymous, consider using a "burner" account in X. Further down the line we might consider opening an email account for reports like this. In that case you can always use something like [Protonmail](https://proton.me/mail) for anonymous emails.
+
+### Our Commitment
+
+When you report a vulnerability to us, we commit to:
+- Acknowledging receipt of your report.
+- Providing an estimated timeframe for addressing the report.
+- Notifying you when the vulnerability has been fixed.
+
+We value your contributions in keeping our project secure and extend our gratitude to the security research community for their responsible disclosure practices.
+
+**Jason Torres** & **Jacob Ashley**
+


### PR DESCRIPTION
I wrote a SECURITY.md file for you and in that there is a section 4 on the how to report section and it talks about using email for anonymous reporting and you can easily delete that part if you are not going to ever use an emil like info@techcommute or security@techcommute etc. for a place to send security reports. Now I used to tell people to use burner X accounts to dm you if they want to be anonymous.

As for the README.md file I fixed the problem with the links as the ones added originally just lead into 404 page in github. Instead using html in md files using md links etc is easier on the eye and faster to build the docs too. I didnt touch on the styling you have there useing html and if you want easy fixes you can just check out the security file. Hope this helps guys! I am your go to guy if you want docs edits and maintaining too. I can do contribution.md too if need be. Drop me a message in X