### PR TITLE
Fixed the hyperlink issue in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,15 @@
 
 # Welcome to the Tech Commute Open Source project!
 
--Help us as we build the website for the Tech Commute! 
+-Help us as we build the website for the Tech Commute!
 <br>
 -Podcast episode links? Images? Schedule/Dates/Guests of the show? We want it all! Contribute and include what YOU think we should utalize this project for!
 <br>
 
-### Tech Commute is a Twitter X Space (and now podcast!) where we learn together, celebrate achievements, and talk to some of the most incredible people in tech on the planet. Join us LIVE on Mondays and Wednesdays (3:50pmEST) and Fridays (11:30am). 
+### Tech Commute is a Twitter X Space (and now podcast!) where we learn together, celebrate achievements, and talk to some of the most incredible people in tech on the planet. Join us LIVE on Mondays and Wednesdays (3:50pmEST) and Fridays (11:30am).
 
 Mondays are our “Tech Topic” consisting of a theme and a guest. <br>
 Wednesdays are our “I’m a Dev, AMA” where YOU bring questions for an experienced dev. <br>
 Fridays we celebrate our wins for the week! Join us and let us know some great things you accomplished through the week!
 
-To listen, follow the hosts for show links: <a href="x.com/tasonjorres">Jason Torres</a> & <a href="x.com/arcadejacob">Jacob Ashley</a>
+To listen, follow the hosts for show links: [Jason Torres](x.com/tasonjorres) & [Jacob Ashley](x.com/arcadejacob)


### PR DESCRIPTION
When you clicked on the link to the hosts's hyperlink that redirects to their twitter/x pages, you would not get redirected to their pages, instead github would display that an issue occured, so i fixed it!